### PR TITLE
changed to VinaGridDNNDocker

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -218,7 +218,7 @@ def dock(protein_fns, ligand_fns):
             ligand_fn = ligand_fns[j]
 
             print("Docking: %s to %s" % (ligand_fn, protein_fn))
-            docker = dc.dock.VinaGridRFDocker(
+            docker = dc.dock.VinaGridDNNDocker(
                 exhaustiveness=1, detect_pockets=False)
             (score, (protein_docked, ligand_docked)
              ) = docker.dock(protein_fn, ligand_fn)


### PR DESCRIPTION
The `dock()` function fails when run in Python 3 during the model's pickle file
loading. The error message states that the pickle file created in Python 2 as the likely culprit. Switching to use the DNN-based docker model allows the `dock()` function to finish computing scores.