### PR TITLE
added more missing parentheses to print statements

### DIFF
--- a/gui/static/ngl/scripts/atom_data.py
+++ b/gui/static/ngl/scripts/atom_data.py
@@ -14,7 +14,7 @@ def main( argv=None ):
     with open( "data/element.txt", "rb" ) as fp:
         for line in fp:
             if line.startswith("#num"):
-                print line
+                print(line)
             elif line.startswith("#"):
                 continue
             else:
@@ -23,8 +23,8 @@ def main( argv=None ):
                 vdw_radii[ element ] = float( row[ 5 ] )
                 covalent_radii[ element ] = float( row[ 3 ] )
 
-    print json.dumps( vdw_radii )
-    print json.dumps( covalent_radii )
+    print(json.dumps( vdw_radii ))
+    print(json.dumps( covalent_radii ))
 
 
 

--- a/gui/static/ngl/scripts/residue_size.py
+++ b/gui/static/ngl/scripts/residue_size.py
@@ -16,7 +16,7 @@ def main( argv=None ):
             res = row[ 0 ].upper()
             res_radii[ res ] = round( float( row[ 1 ] ), 2 )
 
-    print json.dumps( res_radii )
+    print(json.dumps( res_radii ))
 
 
 


### PR DESCRIPTION
added more missing parentheses to print statements to make it compatible with Python 3; there really should be a style checker/linter in an automated continuous integration build process