### PR TITLE
Add deepchem and rdkit to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM deepchemio/deepchem
 
 RUN conda install flask
+RUN pip install rdkit
+RUN conda install -c conda-forge deepchem
 RUN git clone https://github.com/deepchem/deepchem-gui.git && \
 	cd deepchem-gui && \
 	python setup.py install


### PR DESCRIPTION
This PR resolves the issue (https://github.com/deepchem/deepchem-gui/issues/18), adding deepchem and rdkit to the deepchem-gui docker image.